### PR TITLE
Make updateItem support uniqueId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `updateItem` now receives an `Partial<Item>` object as argument.
+
 ## [0.2.1] - 2019-09-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ const MyComponent: FunctionComponent = () => {
 
 ## API
 
-### `updateItem: (index: number, quantity: number) => void`
+### `updateItem: (props: Partial<Item>) => void`
 
-Changes the quantity of the item at position `index` in the `itemList` array to `quantity`. If `quantity` is `0`, the item is removed from the cart.
+Updates an item in the order form. Only properties present in `props` will be changed.
+
+The item is identified either by its `index` in the order form array or its `uniqueId`. One of those properties must be present in `props`. If both are present, `index` will be used to identify the object and `uniqueId` is ignored.
+
+#### Examples
+
+- Removing the third item from the cart:
+```tsx
+updateItem({
+  index: 2,
+  quantity: 0,
+})
+```
+
+- Changing an item's price:
+```tsx
+updateItem({
+  uniqueId: 'E1FDB9F661D74543AE3A13D587641E63',
+  price: 19000,
+})
+```

--- a/react/__mocks__/mockOrderForm.ts
+++ b/react/__mocks__/mockOrderForm.ts
@@ -4,6 +4,7 @@ export const mockOrderForm = {
       additionalInfo: {
         brandName: 'Test Brand 0',
       },
+      availability: 'available',
       id: '1',
       detailUrl: '/work-shirt/p',
       imageUrl:
@@ -17,11 +18,13 @@ export const mockOrderForm = {
       sellingPrice: 2400000,
       skuName: 'Test SKU 0',
       skuSpecifications: [],
+      uniqueId: 'SomeUniqueId0',
     },
     {
       additionalInfo: {
         brandName: 'Test Brand 1',
       },
+      availability: 'available',
       id: '30',
       detailUrl: '/long-sleeve-shirt/p',
       imageUrl:
@@ -35,11 +38,13 @@ export const mockOrderForm = {
       sellingPrice: 945000,
       skuName: 'Test SKU 1',
       skuSpecifications: [],
+      uniqueId: 'SomeUniqueId1',
     },
     {
       additionalInfo: {
         brandName: 'Test Brand 2',
       },
+      availability: 'withoutStock',
       id: '2000535',
       detailUrl: '/classy--sunglasses/p',
       imageUrl:
@@ -53,6 +58,7 @@ export const mockOrderForm = {
       sellingPrice: 360000,
       skuName: 'Test SKU 2',
       skuSpecifications: [],
+      uniqueId: 'SomeUniqueId2',
     },
   ],
   marketingData: null,

--- a/react/package.json
+++ b/react/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@vtex/css-handles": "^1.0.0",
     "classnames": "^2.2.6",
-    "ramda": "^0.26.1",
     "react": "^16.8.3",
     "react-dom": "^16.9.0",
     "react-intl": "^2.7.2",
@@ -27,6 +26,7 @@
     "eslint": "^5.16.0",
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
+    "ramda": "^0.26.1",
     "tslint-eslint-rules": "^5.4.0",
     "typescript": "3.5.2"
   }

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -11,6 +11,7 @@ interface Item {
   detailUrl: string
   id: string
   imageUrl: string
+  index?: number
   listPrice: number
   measurementUnit: string
   name: string
@@ -20,6 +21,7 @@ interface Item {
   sellingPrice: number
   skuName: string
   skuSpecifications: SKUSpecification[]
+  uniqueId: string
 }
 
 interface ItemAdditionalInfo {

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -7,6 +7,7 @@ interface OrderForm {
 
 interface Item {
   additionalInfo: ItemAdditionalInfo
+  availability: string
   detailUrl: string
   id: string
   imageUrl: string


### PR DESCRIPTION
#### What problem is this solving?

In order to use the Checkout API to mutate an item in the product list one must pass its index in the array as argument of the request. This is a bit troublesome because an item's index is not immutable and keeping track of it in the front-end is not very reliable. Waiting for the server response after each operation is not an option because we're implementing optimistic UIs.

This PR makes `updateItem` support identifying an item by its `uniqueId`, which is immutable, making item manipulation in the front-end easier and safer.

#### How should this be manually tested?

[Workspace with `order-items`, `checkout-cart` and `product-list` linked](https://orderitems--vtexgame1.myvtex.com/cart).

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19188/possibilitar-alterar-itens-por-id).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
✔️| Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
