### PR TITLE
Make API functions more specific and debounced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `debouncedUpdateItem` function to the API.
+
 ## [0.3.1] - 2019-09-10
+
+### Changed
+
+- Moved `README.md` to `/docs` folder to comply with VTEX IO docs format.
 
 ## [0.3.0] - 2019-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- `debouncedUpdateItem` function to the API.
+- `updateItem` function has been split into `updateQuantity` and `removeItem`, and both functions are debounced.
 
 ## [0.3.1] - 2019-09-10
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,3 +52,7 @@ updateItem({
   price: 19000,
 })
 ```
+
+### `debouncedUpdateItem: (props: Partial<Item>) => void`
+
+Debounced version of `updateItem`. It updates the local order form immediately but postpones the execution of the update request until after 300ms has elapsed since the last call to the function. All requests from previous calls to this function in the meantime are ignored.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ const MainComponent: FunctionComponent = () => (
 
 const MyComponent: FunctionComponent = () => {
   const { orderForm: { items } } = useOrderManager()
-  const { updateItem } = useOrderItems()
+  const { updateQuantity, removeItem } = useOrderItems()
   // ...
 }
 ```
@@ -38,7 +38,7 @@ This function has a debounce timeout of 300 milliseconds.
 #### Example
 
 ```tsx
-updateItem({
+updateQuantity({
   uniqueId: 'E1FDB9F661D74543AE3A13D587641E63',
   quantity: 3,
 })

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,30 +29,29 @@ const MyComponent: FunctionComponent = () => {
 
 ## API
 
-### `updateItem: (props: Partial<Item>) => void`
+### `updateQuantity: (props: { uniqueId?: string, index?: number, quantity: number }) => void`
 
-Updates an item in the order form. Only properties present in `props` will be changed.
+Updates the quantity of an item in the order form. `props` must contain either the `uniqueId` or `index` of the item to be updated as well as the desired `quantity`.
 
-The item is identified either by its `index` in the order form array or its `uniqueId`. One of those properties must be present in `props`. If both are present, `index` will be used to identify the object and `uniqueId` is ignored.
+This function has a debounce timeout of 300 milliseconds.
 
-#### Examples
+#### Example
 
-- Removing the third item from the cart:
-```tsx
-updateItem({
-  index: 2,
-  quantity: 0,
-})
-```
-
-- Changing an item's price:
 ```tsx
 updateItem({
   uniqueId: 'E1FDB9F661D74543AE3A13D587641E63',
-  price: 19000,
+  quantity: 3,
 })
 ```
 
-### `debouncedUpdateItem: (props: Partial<Item>) => void`
+### `removeItem: (props: { uniqueId?: string, index?: number }) => void`
 
-Debounced version of `updateItem`. It updates the local order form immediately but postpones the execution of the update request until after 300ms has elapsed since the last call to the function. All requests from previous calls to this function in the meantime are ignored.
+Removes an item from the cart. `props` must contain either the `uniqueId` or `index` of the item to be removed.
+
+This function has a debounce timeout of 300 milliseconds.
+
+#### Example
+
+```tsx
+removeItem({ uniqueId: 'E1FDB9F661D74543AE3A13D587641E63' })
+```

--- a/react/__mocks__/debounce.ts
+++ b/react/__mocks__/debounce.ts
@@ -1,0 +1,3 @@
+const debounce = (fn: any, _: number) => fn
+
+export default debounce

--- a/react/package.json
+++ b/react/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@vtex/css-handles": "^1.0.0",
     "classnames": "^2.2.6",
+    "debounce": "^1.2.0",
     "react": "^16.8.3",
     "react-dom": "^16.9.0",
     "react-intl": "^2.7.2",
@@ -13,6 +14,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",
+    "@types/debounce": "^1.2.0",
     "@types/graphql": "^14.2.0",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.13.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -990,6 +990,11 @@
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
   integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
 
+"@types/debounce@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
+  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1843,6 +1848,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
#### What problem is this solving?

The original intent of this PR was to add a debouncer to the `updateItem` function by exposing a new `debouncedUpdateItem` function in the API. After some discussion, we realized having both of these functions could confuse a developer that would use this API.

To solve this, we're changing the API from a `updateItem` function that does everything to functions with more specific use cases (`updateQuantity`, `removeItem` and, in the future, `updatePrice`). We're opinionating the implementation of those functions to be debounced by default.

#### How should this be manually tested?

[Workspace](http://debounce--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19051/implementar-debouncer).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

I've kept the older commits from this PR to make it easier to review the following changes, but once this is approved I'll rewrite the commit history to make it cleaner.
