### PR TITLE
Fix optimistic calculation of totalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Optimistic calculation of the totalizers doesn't consider unavailable items anymore.
+
 ## [0.4.0] - 2019-09-13
 
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

There was an inconsistency between the optimistic calculation of the totalizers and the value returned by the Checkout API because the former considered unavailable items while the latter did not. This led to a weird behavior when removing an unavailable item from the cart: the item price was subtracted from the total value and then it returned to the original value once the requested resolved.

This PR fixes this issue by simply not updating the totalizers when the updated item is unavailable.

#### How should this be manually tested?

[Workspace](https://optimistic--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19728/cálculo-otimista-do-total-não-deve-considerar-itens-indisponíveis).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
