### PR TITLE
Use useQueueStatus from OrderQueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Small code refactor.
+
 ## [0.4.1] - 2019-09-16
 
 ### Fixed

--- a/react/__mocks__/vtex.order-manager/OrderQueue.tsx
+++ b/react/__mocks__/vtex.order-manager/OrderQueue.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC, useContext, useMemo } from 'react'
+import React, { createContext, FC, useContext, useMemo, useRef } from 'react'
 
 interface Context {
   enqueue: (_: any) => Promise<any>
@@ -25,4 +25,13 @@ export const OrderQueueProvider: FC = ({ children }: any) => {
 
 export const useOrderQueue = () => {
   return useContext(OrderQueueContext)
+}
+
+export const useQueueStatus = (_: any) => {
+  return useRef('Fulfilled')
+}
+
+export enum QueueStatus {
+  PENDING = 'Pending',
+  FULFILLED = 'Fulfilled',
 }


### PR DESCRIPTION
~**Note:** _This PR depends on https://github.com/vtex-apps/order-manager/pull/11 and **cannot be merged** before it._~

#### What problem is this solving?

The logic to create a `ref` object containing the status of the queue [has been moved](https://github.com/vtex-apps/order-manager/pull/11) to `OrderQueue` because it is being used in multiple repositories. This PR changes `OrderItems` to use the new `useQueueStatus` hook from `OrderQueue` that does this job.

#### How should this be manually tested?

`yarn test` and [this workspace](https://queuestatus--vtexgame1.myvtex.com/cart).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
