### PR TITLE
Fix optimistic calculation of totalizers (once again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+ Optimistic calculation of totalizers when some kinds of discounts are applied.
+
 ## [0.4.2] - 2019-10-04
 
 ### Changed

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -19,8 +19,12 @@ import { useOrderForm } from 'vtex.order-manager/OrderForm'
 const DEBOUNCE_TIME_MS = 300
 
 const AVAILABLE = 'available'
-const SUBTOTAL_TOTALIZER_ID = 'Items'
 const TASK_CANCELLED = 'TASK_CANCELLED'
+
+enum Totalizers {
+  SUBTOTAL = 'Items',
+  DISCOUNT = 'Discounts',
+}
 
 interface Context {
   updateQuantity: (props: Partial<Item>) => void
@@ -62,13 +66,21 @@ const maybeUpdateTotalizers = (
   const newPrice = newItem.price * newItem.quantity
   const subtotalDifference = newPrice - oldPrice
 
+  const oldDiscount = (oldItem.sellingPrice - oldItem.price) * oldItem.quantity
+  const newDiscount = (newItem.sellingPrice - newItem.price) * newItem.quantity
+  const discountDifference = newDiscount - oldDiscount
+
   const newTotalizers = totalizers.map((totalizer: Totalizer) => {
-    if (totalizer.id !== SUBTOTAL_TOTALIZER_ID) {
-      return totalizer
+    switch (totalizer.id) {
+      case Totalizers.SUBTOTAL:
+        return { ...totalizer, value: totalizer.value + subtotalDifference }
+      case Totalizers.DISCOUNT:
+        return { ...totalizer, value: totalizer.value + discountDifference }
+      default:
+        return totalizer
     }
-    return { ...totalizer, value: totalizer.value + subtotalDifference }
   })
-  const newValue = value + subtotalDifference
+  const newValue = value + subtotalDifference + discountDifference
 
   return { totalizers: newTotalizers, value: newValue }
 }


### PR DESCRIPTION
#### What problem is this solving?

The optimistic calculation of totalizers is not considering some kinds of discount applied to items, because it is not taking the `sellingPrice` into account. This causes inconsistencies between the calculated totalizers and the ones returned by the API. This PR fixes this issue by correctly calculating the Subtotal and Discounts totalizers.

#### How should this be manually tested?

Use [this workspace](https://optimistic--vtexgame1.myvtex.com/cart), add some random items and use the `teste50p` coupon, which applies 50% discount to all items. Change the quantity of items in the cart and verify the values of the totalizers do not change after the request finishes.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23554/cálculo-otimista-do-total-não-considera-desconto-de-cupon).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
