### PR TITLE
Remove debounce from API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- API methods are not debounced anymore.
+
 ## [0.4.3] - 2019-10-10
 
 ### Fixed

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -6,8 +6,6 @@ import React, {
   useMemo,
 } from 'react'
 import { graphql } from 'react-apollo'
-import debounce from 'debounce'
-import { memoizeWith } from 'ramda'
 import { updateItems as UpdateItem } from 'vtex.checkout-resources/Mutations'
 import {
   QueueStatus,
@@ -15,8 +13,6 @@ import {
   useQueueStatus,
 } from 'vtex.order-manager/OrderQueue'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
-
-const DEBOUNCE_TIME_MS = 300
 
 const AVAILABLE = 'available'
 const TASK_CANCELLED = 'TASK_CANCELLED'
@@ -111,11 +107,6 @@ const enqueueTask = ({
     })
 }
 
-const debouncedEnqueueTask = memoizeWith(
-  (taskId: string) => taskId,
-  (_: string) => debounce(enqueueTask, DEBOUNCE_TIME_MS)
-)
-
 export const OrderItemsProvider = graphql(UpdateItem, {
   name: 'UpdateItem',
 })(({ children, UpdateItem }: any) => {
@@ -197,7 +188,7 @@ export const OrderItemsProvider = graphql(UpdateItem, {
       const { index, uniqueId } = itemIds(props)
       updateOrderForm(index, { quantity: props.quantity })
       const taskId = `updateQuantity-${uniqueId}`
-      debouncedEnqueueTask(taskId)({
+      enqueueTask({
         task: mutationTask({ uniqueId, quantity: props.quantity }),
         enqueue,
         queueStatusRef,


### PR DESCRIPTION
#### What problem is this solving?

We had added a debounce to some of the API methods to prevent sending too many requests to the server. However, this introduced a bug in the quantity selector. Consider the following scenario, in which events happen in the order they are described:

- User types `1`: `1` debounce starts, optimistic UI shows `1` on screen
- `1` debounce ends, `1` processing starts, queue becomes busy
- User types `2`: `2` debounce starts, optimistic UI shows `12` on screen
- `1` processing ends, queue becomes free, UI shows `1` on screen _incorrectly_
- `2` debounce ends, `2` processing starts, queue becomes busy
- `2` processing ends, queue becomes free, UI shows `12` on screen once again

We initially prevented this behavior by only optimistically updating the UI when the queue is empty. However, the addition of debouncing reintroduced it.

The solution was to simply remove the debouncing. It is not really necessary because the task queue (which runs client-side) already cancels a task when a newer one with the same `taskId` is pushed.

#### How should this be manually tested?

Use [this workspace](https://orderitems--vtexgame1.myvtex.com/cart).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
