### PR TITLE
Merge enqueued updateItem operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Enqueued `updateItem` mutations are now merged together to prevent the task queue from growing too much.
+
 ## [0.4.4] - 2019-10-10
 
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

We must enqueue requests to Checkout API because it doesn't handle concurrent requests quite well. As a consequence, if the user triggers several requests in a row (for instance, when removing many items from the cart at once), that creates a huge queue of requests that takes a lot of time to clear. This is bad because if the user refreshes the page while the queue is not empty, all pending requests are lost, bringing a bad experience to the user.

This PR tries to mitigate this problem by merging `updateItem` mutations. The idea is that if we need to update an item when there's already a `updateItem` request enqueued, we cancel the older request, merge both mutations and send a new request with both updates. This prevents the queue from growing too much when the user interacts with the product list.

#### How should this be manually tested?

[Add 10 items to your cart](https://marcos2--checkoutio.myvtex.com/cart/add?sku=291&sku=256&sku=287&sku=308&sku=288&sku=306&sku=330&sku=36&sku=269&sku=321), then remove them all as fast as you can. Once you're done, open the console. There should be a message indicating the time it took to clear the queue (this is a change in `checkout-cart` made just for this test). It should take less than 2 seconds.

Repeat the test [with this workspace](https://marcos3--checkoutio.myvtex.com/cart/add?sku=291&sku=256&sku=287&sku=308&sku=288&sku=306&sku=330&sku=36&sku=269&sku=321), which does not contain this optimization, and verify it takes much longer to empty the queue (over 10 seconds).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
