### PR TITLE
Treat error when order form is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Treats case when OrderManager fails to fetch order form and provides a better error message when that happens.
+
 ## [0.5.0] - 2019-11-06
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,6 @@ const MyComponent: FunctionComponent = () => {
 
 Updates the quantity of an item in the order form. `props` must contain either the `uniqueId` or `index` of the item to be updated as well as the desired `quantity`.
 
-This function has a debounce timeout of 300 milliseconds.
-
 #### Example
 
 ```tsx
@@ -47,8 +45,6 @@ updateQuantity({
 ### `removeItem: (props: { uniqueId?: string, index?: number }) => void`
 
 Removes an item from the cart. `props` must contain either the `uniqueId` or `index` of the item to be removed.
-
-This function has a debounce timeout of 300 milliseconds.
 
 #### Example
 

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -107,11 +107,7 @@ const enqueueTask = ({
 
 export const OrderItemsProvider: FC = ({ children }) => {
   const { enqueue, listen, isWaiting } = useOrderQueue()
-  const {
-    loading,
-    orderForm: { items, totalizers, value: orderFormValue },
-    setOrderForm,
-  } = useOrderForm()
+  const { loading, orderForm, setOrderForm } = useOrderForm()
 
   const [updateItems] = useMutation(UpdateItems)
 
@@ -120,6 +116,12 @@ export const OrderItemsProvider: FC = ({ children }) => {
     promise: undefined,
     variables: undefined,
   } as EnqueuedTask)
+
+  if (!orderForm) {
+    throw new Error('Unable to fetch order form.')
+  }
+
+  const { items, totalizers, value: orderFormValue } = orderForm
 
   const itemIds = useCallback(
     (props: Partial<Item>) => {

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -1,6 +1,5 @@
 import React, {
   createContext,
-  FunctionComponent,
   useCallback,
   useContext,
   useMemo,
@@ -40,23 +39,6 @@ interface EnqueuedTask {
 const OrderItemsContext = createContext<Context | undefined>(undefined)
 
 const noop = async (_: Partial<Item>) => {}
-
-const LoadingState: FunctionComponent = ({ children }: any) => {
-  const value = useMemo(
-    () => ({
-      itemList: [],
-      updateQuantity: noop,
-      removeItem: noop,
-      loading: true,
-    }),
-    []
-  )
-  return (
-    <OrderItemsContext.Provider value={value}>
-      {children}
-    </OrderItemsContext.Provider>
-  )
-}
 
 const maybeUpdateTotalizers = (
   totalizers: Totalizer[],
@@ -131,10 +113,6 @@ export const OrderItemsProvider = graphql(UpdateItem, {
     orderForm: { items, totalizers, value: orderFormValue },
     setOrderForm,
   } = useOrderForm()
-
-  if (loading) {
-    return <LoadingState>{children}</LoadingState>
-  }
 
   const queueStatusRef = useQueueStatus(listen)
   const lastUpdateTaskRef = useRef({
@@ -236,10 +214,16 @@ export const OrderItemsProvider = graphql(UpdateItem, {
     [updateQuantity]
   )
 
-  const value = useMemo(() => ({ updateQuantity, removeItem }), [
-    updateQuantity,
-    removeItem,
-  ])
+  const value = useMemo(
+    () =>
+      loading
+        ? {
+            updateQuantity: noop,
+            removeItem: noop,
+          }
+        : { updateQuantity, removeItem },
+    [loading, updateQuantity, removeItem]
+  )
 
   return (
     <OrderItemsContext.Provider value={value}>

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -1,12 +1,13 @@
 import React, {
   createContext,
+  FC,
   useCallback,
   useContext,
   useMemo,
   useRef,
 } from 'react'
-import { graphql } from 'react-apollo'
-import { updateItems as UpdateItem } from 'vtex.checkout-resources/Mutations'
+import { useMutation } from 'react-apollo'
+import { updateItems as UpdateItems } from 'vtex.checkout-resources/Mutations'
 import {
   QueueStatus,
   useOrderQueue,
@@ -104,15 +105,15 @@ const enqueueTask = ({
   return newPromise
 }
 
-export const OrderItemsProvider = graphql(UpdateItem, {
-  name: 'UpdateItem',
-})(({ children, UpdateItem }: any) => {
+export const OrderItemsProvider: FC = ({ children }) => {
   const { enqueue, listen, isWaiting } = useOrderQueue()
   const {
     loading,
     orderForm: { items, totalizers, value: orderFormValue },
     setOrderForm,
   } = useOrderForm()
+
+  const [updateItems] = useMutation(UpdateItems)
 
   const queueStatusRef = useQueueStatus(listen)
   const lastUpdateTaskRef = useRef({
@@ -169,7 +170,7 @@ export const OrderItemsProvider = graphql(UpdateItem, {
     (items: Partial<Item>[]) => async () => {
       const {
         data: { updateItems: newOrderForm },
-      } = await UpdateItem({
+      } = await updateItems({
         variables: {
           orderItems: items,
         },
@@ -177,7 +178,7 @@ export const OrderItemsProvider = graphql(UpdateItem, {
 
       return newOrderForm
     },
-    [UpdateItem]
+    [updateItems]
   )
 
   const updateQuantity = useCallback(
@@ -230,7 +231,7 @@ export const OrderItemsProvider = graphql(UpdateItem, {
       {children}
     </OrderItemsContext.Provider>
   )
-})
+}
 
 export const useOrderItems = () => {
   const context = useContext(OrderItemsContext)

--- a/react/__tests__/OrderItems.test.tsx
+++ b/react/__tests__/OrderItems.test.tsx
@@ -1,5 +1,6 @@
 import { adjust } from 'ramda'
 import React, { FunctionComponent } from 'react'
+import { MockedProvider } from '@apollo/react-testing'
 import { act, render, fireEvent } from '@vtex/test-tools/react'
 import { updateItems as UpdateItem } from 'vtex.checkout-resources/Mutations'
 import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
@@ -75,14 +76,15 @@ describe('OrderItems', () => {
     )
 
     const { getByText } = render(
-      <OrderQueueProvider>
-        <OrderFormProvider>
-          <OrderItemsProvider>
-            <Component />
-          </OrderItemsProvider>
-        </OrderFormProvider>
-      </OrderQueueProvider>,
-      { graphql: { mocks: [mockUpdateItem] } }
+      <MockedProvider mocks={[mockUpdateItem]} addTypename={false}>
+        <OrderQueueProvider>
+          <OrderFormProvider>
+            <OrderItemsProvider>
+              <Component />
+            </OrderItemsProvider>
+          </OrderFormProvider>
+        </OrderQueueProvider>
+      </MockedProvider>
     )
 
     const button = getByText('mutate')
@@ -126,14 +128,15 @@ describe('OrderItems', () => {
     )
 
     const { getByText, queryByText } = render(
-      <OrderQueueProvider>
-        <OrderFormProvider>
-          <OrderItemsProvider>
-            <Component />
-          </OrderItemsProvider>
-        </OrderFormProvider>
-      </OrderQueueProvider>,
-      { graphql: { mocks: [mockUpdateItem] } }
+      <MockedProvider mocks={[mockUpdateItem]} addTypename={false}>
+        <OrderQueueProvider>
+          <OrderFormProvider>
+            <OrderItemsProvider>
+              <Component />
+            </OrderItemsProvider>
+          </OrderFormProvider>
+        </OrderQueueProvider>
+      </MockedProvider>
     )
 
     const button = getByText('mutate')

--- a/react/package.json
+++ b/react/package.json
@@ -29,6 +29,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "ramda": "^0.26.1",
+    "react-apollo": "^3.1.3",
     "tslint-eslint-rules": "^5.4.0",
     "typescript": "3.5.2"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -13,6 +13,7 @@
     "recompose": "^0.30.0"
   },
   "devDependencies": {
+    "@apollo/react-testing": "^3.1.3",
     "@types/classnames": "^2.2.7",
     "@types/debounce": "^1.2.0",
     "@types/graphql": "^14.2.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -51,6 +51,15 @@
     "@apollo/react-hooks" "^3.1.3"
     tslib "^1.10.0"
 
+"@apollo/react-testing@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-3.1.3.tgz#d8dd318f58fb6a404976bfa3f8a79e976a5c6562"
+  integrity sha512-58R7gROl4TZMHm5kS76Nof9FfZhD703AU3SmJTA2f7naiMqC9Qd8pZ4oNCBafcab0SYN//UtWvLcluK5O7V/9g==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    fast-json-stable-stringify "^2.0.0"
+    tslib "^1.10.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2,6 +2,55 @@
 # yarn lockfile v1
 
 
+"@apollo/react-common@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.3.tgz#ddc34f6403f55d47c0da147fd4756dfd7c73dac5"
+  integrity sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==
+  dependencies:
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-components@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.3.tgz#8f6726847cd9b0eb4b22586b1a038d29aa8b1da4"
+  integrity sha512-H0l2JKDQMz+LkM93QK7j3ThbNXkWQCduN3s3eKxFN3Rdg7rXsrikJWvx2wQ868jmqy0VhwJbS1vYdRLdh114uQ==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-hooks" "^3.1.3"
+    prop-types "^15.7.2"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hoc@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hoc/-/react-hoc-3.1.3.tgz#5742ee74f57611058f5ea1f966c38fc6429dda7b"
+  integrity sha512-oCPma0uBVPTcYTR5sOvtMbpaWll4xDBvYfKr6YkDorUcQVeNzFu1LK1kmQjJP64bKsaziKYji5ibFaeCnVptmA==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-components" "^3.1.3"
+    hoist-non-react-statics "^3.3.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hooks@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.3.tgz#ad42c7af78e81fee0f30e53242640410d5bd0293"
+  integrity sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@wry/equality" "^0.1.9"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-ssr@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-3.1.3.tgz#0791280d5b735f42f87dbfe849564e78843045bc"
+  integrity sha512-fUTmEYHxSTX1GA43B8vICxXXplpcEBnDwn0IgdAc3eG0p2YK97ZrJDRFCJ5vD7fyDZsrYhMf+rAI3sd+H2SS+A==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-hooks" "^3.1.3"
+    tslib "^1.10.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -1196,7 +1245,7 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2":
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
@@ -4338,6 +4387,17 @@ react-apollo@^2.5.2:
     ts-invariant "^0.4.2"
     tslib "^1.9.3"
 
+react-apollo@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-3.1.3.tgz#5d8540b401bba36173b63e6c5e75fa561960c63e"
+  integrity sha512-orCZNoAkgveaK5b75y7fw1MSqSHOU/Wuu9rRFOGmRQBSQVZjvV4DI+hj604rHmuN9+WDABxb5W48wTa0F/xNZQ==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-components" "^3.1.3"
+    "@apollo/react-hoc" "^3.1.3"
+    "@apollo/react-hooks" "^3.1.3"
+    "@apollo/react-ssr" "^3.1.3"
+
 react-dom@^16.8.4, react-dom@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
@@ -5135,7 +5195,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-invariant@^0.4.0, ts-invariant@^0.4.2:
+ts-invariant@^0.4.0, ts-invariant@^0.4.2, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
@@ -5152,7 +5212,7 @@ tslib@1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
#### What problem is this solving?

When OrderManager finishes loading, OrderItems expects `orderForm` to contain the appropriate data. However, if the query that fetches the order form fails, OrderManager sets orderForm to `undefined` and OrderItems breaks with `Cannot read property 'items' of undefined`. This PR treats this case and provides a better error message when that happens.

#### How should this be manually tested?

Simply interact with the product list of [this workspace](https://error--checkoutio.myvtex.com/cart/add?sku=291&sku=256&sku=287&sku=308&sku=288&sku=306&sku=330&sku=36&sku=269&sku=321).

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/25132/tratar-erro-de-graphql).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
