### PR TITLE
Add addItemToCart function to OrderItemsProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `addItemToCart` function to `OrderItemsProvider`.
 
 ## [0.5.1] - 2019-11-25
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ Add an item to the cart. `props` must be a list with the `items` to be added to 
 #### Example
 
 ```tsx
-addItemToCart([{{
+addItemToCart([{
       id: '2000535',
       listPrice: 400000,
       name: 'Camisa Vasco',
@@ -70,4 +70,4 @@ addItemToCart([{{
       skuName: 'Test SKU 2',
       skuSpecifications: [],
       uniqueId: 'SomeUniqueId2',
-    }}])
+    }])

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,14 +60,15 @@ Add an item to the cart. `props` must be a list with the `items` to be added to 
 
 ```tsx
 addItemToCart([{
-                id: '2000535',
-                listPrice: 400000,
-                name: 'Vasco Football T-shirt',
-                price: 360000,
-                productId: '13',
-                quantity: 4,
-                sellingPrice: 360000,
-                skuName: 'Test SKU 2',
-                skuSpecifications: [],
-                uniqueId: 'SomeUniqueId2',
-              }])
+  id: '2000535',
+  listPrice: 400000,
+  name: 'Vasco Football T-shirt',
+  price: 360000,
+  productId: '13',
+  quantity: 4,
+  sellingPrice: 360000,
+  skuName: 'Test SKU 2',
+  skuSpecifications: [],
+  uniqueId: 'SomeUniqueId2',
+}])
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,3 +51,23 @@ Removes an item from the cart. `props` must contain either the `uniqueId` or `in
 ```tsx
 removeItem({ uniqueId: 'E1FDB9F661D74543AE3A13D587641E63' })
 ```
+
+### `addItemToCart: (props: [Item]) => Promise<{data: OrderForm, error: boolean}>`
+
+Add an item to the cart. `props` must be a list with the `items` to be added to the cart.
+
+#### Example
+
+```tsx
+addItemToCart([{{
+      id: '2000535',
+      listPrice: 400000,
+      name: 'Camisa Vasco',
+      price: 360000,
+      productId: '13',
+      quantity: 4,
+      sellingPrice: 360000,
+      skuName: 'Test SKU 2',
+      skuSpecifications: [],
+      uniqueId: 'SomeUniqueId2',
+    }}])

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,14 +60,14 @@ Add an item to the cart. `props` must be a list with the `items` to be added to 
 
 ```tsx
 addItemToCart([{
-      id: '2000535',
-      listPrice: 400000,
-      name: 'Camisa Vasco',
-      price: 360000,
-      productId: '13',
-      quantity: 4,
-      sellingPrice: 360000,
-      skuName: 'Test SKU 2',
-      skuSpecifications: [],
-      uniqueId: 'SomeUniqueId2',
-    }])
+                id: '2000535',
+                listPrice: 400000,
+                name: 'Vasco Football T-shirt',
+                price: 360000,
+                productId: '13',
+                quantity: 4,
+                sellingPrice: 360000,
+                skuName: 'Test SKU 2',
+                skuSpecifications: [],
+                uniqueId: 'SomeUniqueId2',
+              }])

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -29,7 +29,7 @@ enum Totalizers {
 interface Context {
   updateQuantity: (props: Partial<Item>) => void
   removeItem: (props: Partial<Item>) => void
-  addItemToCart: (items: Item[]) => void
+  addItemToCart: (items: Partial<Item>[]) => void
 }
 
 interface CancellablePromiseLike<T> extends Promise<T> {
@@ -222,7 +222,7 @@ export const OrderItemsProvider: FC = ({ children }) => {
     [updateQuantity]
   )
 
-  const addItemToCart = async (items: Item[]) => {
+  const addItemToCart = async (items: Partial<Item>[]) => {
     const task = async () => {
       try {
         const {

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -29,7 +29,7 @@ enum Totalizers {
 interface Context {
   updateQuantity: (props: Partial<Item>) => void
   removeItem: (props: Partial<Item>) => void
-  addItemToCart: (items: Partial<Item>[]) => void
+  addItemToCart: (props: Partial<Item>[]) => void
 }
 
 interface CancellablePromiseLike<T> extends Promise<T> {
@@ -43,7 +43,8 @@ interface EnqueuedTask {
 
 const OrderItemsContext = createContext<Context | undefined>(undefined)
 
-const noop = async (_: Partial<Item>) => {}
+const noopItem = async (_: Partial<Item>) => {}
+const noopItems = async (_: Partial<Item>[]) => {}
 
 const maybeUpdateTotalizers = (
   totalizers: Totalizer[],
@@ -248,9 +249,9 @@ export const OrderItemsProvider: FC = ({ children }) => {
     () =>
       loading
         ? {
-            updateQuantity: noop,
-            removeItem: noop,
-            addItemToCart: () => {},
+            updateQuantity: noopItem,
+            removeItem: noopItem,
+            addItemToCart: noopItems,
           }
         : { addItemToCart, updateQuantity, removeItem },
     [loading, updateQuantity, removeItem]

--- a/react/__mocks__/vtex.checkout-resources/Mutations.ts
+++ b/react/__mocks__/vtex.checkout-resources/Mutations.ts
@@ -7,3 +7,11 @@ export const updateItems = gql`
     }
   }
 `
+
+export const addToCart = gql`
+  mutation MockMutation($items: [ItemInput]) {
+    addToCart(items: $items) {
+      items
+    }
+  }
+`

--- a/react/__tests__/OrderItems.test.tsx
+++ b/react/__tests__/OrderItems.test.tsx
@@ -190,9 +190,7 @@ describe('OrderItems', () => {
           {items.map((item: Partial<Item>) => (
             <div key={item.name}>{item.name}</div>
           ))}
-          <button onClick={() => addItemToCart([...items, newItem])}>
-            mutate
-          </button>
+          <button onClick={() => addItemToCart([newItem])}>mutate</button>
         </div>
       )
     }
@@ -207,7 +205,7 @@ describe('OrderItems', () => {
     }
 
     const mockAddItemToCart = mockAddToCartMutation(
-      [...mockOrderForm.items, newItem],
+      [newItem],
       [...mockOrderForm.items, newItem]
     )
 

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "ramda": "^0.26.1",
     "react-apollo": "^3.1.3",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "0.5.1"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5261,10 +5261,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the `addItemToCart` function to `OrderItemsProvider`. This allows UI components to use `order-items` to add items to cart and also, with that, we ensure an up to date `orderForm`, since we remove the `orderForm` update responsibility from the UI components which used to call `addToCart` mutation directly.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to [Workspace](https://buybuttoncart--checkoutio.myvtex.com/)
- Add an item to cart
- Check if it's working properly

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/28348/eu-como-comprador-tendo-visitado-a-loja-n%C3%A3o-quero-ver-o-carregamento-do-carrinho)
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
