### PR TITLE
Use new entrypoint for updateItems mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use the separate `default export`s from `vtex.checkout-resources`.
+
 ## [0.5.1] - 2019-11-25
 
 ### Changed

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
 } from 'react'
 import { useMutation } from 'react-apollo'
-import { updateItems as UpdateItems } from 'vtex.checkout-resources/Mutations'
+import UpdateItems from 'vtex.checkout-resources/MutationUpdateItems'
 import {
   QueueStatus,
   useOrderQueue,

--- a/react/__mocks__/vtex.checkout-resources/MutationUpdateItems.ts
+++ b/react/__mocks__/vtex.checkout-resources/MutationUpdateItems.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-export const updateItems = gql`
+export default gql`
   mutation MockMutation($orderItems: [ItemInput]) {
     updateItems(orderItems: $orderItems) {
       items

--- a/react/__tests__/OrderItems.test.tsx
+++ b/react/__tests__/OrderItems.test.tsx
@@ -2,7 +2,7 @@ import { adjust } from 'ramda'
 import React, { FunctionComponent } from 'react'
 import { MockedProvider } from '@apollo/react-testing'
 import { act, render, fireEvent } from '@vtex/test-tools/react'
-import { updateItems as UpdateItem } from 'vtex.checkout-resources/Mutations'
+import UpdateItem from 'vtex.checkout-resources/MutationUpdateItems'
 import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
 import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
 

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,7 @@
     "ramda": "^0.26.1",
     "react-apollo": "^3.1.3",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "0.5.1"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5261,10 +5261,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### What problem is this solving?

We are avoiding importing huge `default export`s with multiple GraphQL queries/mutations because that hinders performance. This PR changes `order-items` to use the separate `default export`s from `checkout-resources`, which exports just a single query/mutation.

#### How should this be manually tested?

`yarn test` and [this workspace](https://split--checkoutio.myvtex.com)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/31936/mudar-orquestradores-para-usarem-os-novos-entrypoints-de-queries-e-mutations-do-checkout-resources).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
