### PR TITLE
Fix error after unsuccessful add item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error on the add to cart function if one of the items wasn't successfully added to the cart.
 
 ## [0.7.5] - 2020-05-08
 ### Fixed

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -196,7 +196,14 @@ const useAddItemsTask = (
         orderFormItems.forEach(orderFormItem => {
           const updatedItem = updatedOrderForm.items.find(
             updatedOrderFormItem => updatedOrderFormItem.id === orderFormItem.id
-          )!
+          )
+
+          if (!updatedItem) {
+            // the item wasn't added to the cart. the reason for this
+            // may vary, but could be something like the item doesn't
+            // have stock left, etc.
+            return
+          }
 
           const fakeUniqueId = orderFormItem.uniqueId
 
@@ -213,25 +220,32 @@ const useAddItemsTask = (
         setOrderForm(prevOrderForm => {
           return {
             ...prevOrderForm,
-            items: prevOrderForm.items.map(item => {
-              const inputIndex = mutationInputItems.findIndex(
-                inputItem => inputItem.id === +item.id
-              )
+            items: prevOrderForm.items
+              .map(item => {
+                const inputIndex = mutationInputItems.findIndex(
+                  inputItem => inputItem.id === +item.id
+                )
 
-              if (inputIndex === -1) {
-                // this item wasn't part of the initial mutation, skip it
-                return item
-              }
+                if (inputIndex === -1) {
+                  // this item wasn't part of the initial mutation, skip it
+                  return item
+                }
 
-              const updatedItem = updatedOrderForm.items.find(
-                updatedOrderFormItem => updatedOrderFormItem.id === item.id
-              )!
+                const updatedItem = updatedOrderForm.items.find(
+                  updatedOrderFormItem => updatedOrderFormItem.id === item.id
+                )
 
-              return {
-                ...item,
-                uniqueId: updatedItem.uniqueId,
-              }
-            }),
+                if (!updatedItem) {
+                  // item was not added to the cart
+                  return null
+                }
+
+                return {
+                  ...item,
+                  uniqueId: updatedItem.uniqueId,
+                }
+              })
+              .filter((item): item is Item => item != null),
             marketingData:
               mutationInputMarketingData ?? prevOrderForm.marketingData,
           }

--- a/react/__fixtures__/mockOrderForm.ts
+++ b/react/__fixtures__/mockOrderForm.ts
@@ -74,3 +74,25 @@ export const mockOrderForm = Object.freeze({
   ],
   value: 9585000,
 })
+
+export const mockCatalogItem: CatalogItem = {
+  id: '140133',
+  productId: '256019',
+  availability: 'AVAILABLE',
+  quantity: 1,
+  uniqueId: '',
+  detailUrl: '/macacao-pantalona-xo-uruca-preto-266569-0013-256019/p',
+  name: 'Macacao Pantalona Xo Uruca',
+  additionalInfo: {
+    brandName: 'Farm',
+  },
+  seller: 'lojafarm',
+  skuName: 'Preto - PP',
+  price: 69800,
+  listPrice: 69800,
+  sellingPrice: 69800,
+  measurementUnit: 'un',
+  skuSpecifications: [],
+  imageUrl:
+    'https://lojafarm.vtexassets.com/arquivos/ids/1930594-55-55/266569_0013_1-MACACAO-PANTALONA-XO-URUCA.jpg',
+}

--- a/react/__mocks__/vtex.checkout-resources/MutationAddToCart.ts
+++ b/react/__mocks__/vtex.checkout-resources/MutationAddToCart.ts
@@ -1,7 +1,16 @@
 import gql from 'graphql-tag'
 
 export default gql`
-  mutation MockAddToCart($items: [ItemInput]) {
-    items
+  mutation MockAddToCart($items: [ItemInput], $marketingData: MarketingData) {
+    addToCart(items: $items, marketingData: $marketingData) {
+      items
+      messages {
+        generalMessages {
+          code
+          text
+          status
+        }
+      }
+    }
   }
 `

--- a/react/typings/jest.d.ts
+++ b/react/typings/jest.d.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes an issue when the user adds an item to the cart but the item isn't successfully added, in case the item doesn't have stock or any other error.

#### How should this be manually tested?

[Workspace](https://lucas--gc-cli6734.myvtex.com/macacao-pantalona-xo-uruca-preto-266569-0013-256019/p). The changes of this PR are linked in this workspace.

Test plan:

1. Add the product in the link above.
2. After the mutation resolves, the item should be removed from the cart.

You can see the error in the master workspace ([quick link](https://gc-cli6734.myvtex.com/macacao-pantalona-xo-uruca-preto-266569-0013-256019/p)).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->