### PR TITLE
feat: add same sku with more than one seller

### DIFF
--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -195,9 +195,9 @@ const useAddItemsTask = (
         // added locally with the value from the server
         orderFormItems.forEach(orderFormItem => {
           const updatedItem = updatedOrderForm.items.find(
-            // @ts-ignore
             updatedOrderFormItem =>
               updatedOrderFormItem.id === orderFormItem.id &&
+              // @ts-ignore
               updatedOrderFormItem.seller === orderFormItem.seller
           )
 
@@ -226,9 +226,9 @@ const useAddItemsTask = (
             items: prevOrderForm.items
               .map(item => {
                 const inputIndex = mutationInputItems.findIndex(
-                  // @ts-ignore
                   inputItem =>
                     inputItem.id === +item.id &&
+                    // @ts-ignore
                     inputItem.seller === item.seller
                 )
 
@@ -238,9 +238,9 @@ const useAddItemsTask = (
                 }
 
                 const updatedItem = updatedOrderForm.items.find(
-                  // @ts-ignore
                   updatedOrderFormItem =>
                     updatedOrderFormItem.id === item.id &&
+                    // @ts-ignore
                     updatedOrderFormItem.seller === item.seller
                 )
 
@@ -439,9 +439,9 @@ export const OrderItemsProvider: FC = ({ children }) => {
       const mutationInputItems = items.map(adjustForItemInput).filter(
         itemInput =>
           orderFormItemsRef.current.findIndex(
-            // @ts-ignore
             orderFormItem =>
               itemInput.id!.toString() === orderFormItem.id &&
+              // @ts-ignore
               itemInput.seller === orderFormItem.seller
           ) === -1
       )
@@ -459,8 +459,8 @@ export const OrderItemsProvider: FC = ({ children }) => {
           orderFormItem =>
             orderFormItemsRef.current.findIndex(
               (item: any) =>
-                // @ts-ignore
                 item.id === orderFormItem.id &&
+                // @ts-ignore
                 item.seller === orderFormItem.seller
             ) === -1
         )

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -195,7 +195,8 @@ const useAddItemsTask = (
         // added locally with the value from the server
         orderFormItems.forEach(orderFormItem => {
           const updatedItem = updatedOrderForm.items.find(
-            updatedOrderFormItem => updatedOrderFormItem.id === orderFormItem.id
+            // @ts-ignore
+            updatedOrderFormItem => updatedOrderFormItem.id === orderFormItem.id && updatedOrderFormItem.seller === orderFormItem.seller
           )
 
           if (!updatedItem) {
@@ -223,7 +224,8 @@ const useAddItemsTask = (
             items: prevOrderForm.items
               .map(item => {
                 const inputIndex = mutationInputItems.findIndex(
-                  inputItem => inputItem.id === +item.id
+                  // @ts-ignore
+                  inputItem => inputItem.id === +item.id && inputItem.seller === item.seller
                 )
 
                 if (inputIndex === -1) {
@@ -232,7 +234,8 @@ const useAddItemsTask = (
                 }
 
                 const updatedItem = updatedOrderForm.items.find(
-                  updatedOrderFormItem => updatedOrderFormItem.id === item.id
+                  // @ts-ignore
+                  updatedOrderFormItem => updatedOrderFormItem.id === item.id && updatedOrderFormItem.seller === item.seller
                 )
 
                 if (!updatedItem) {
@@ -429,24 +432,26 @@ export const OrderItemsProvider: FC = ({ children }) => {
     ) => {
       const mutationInputItems = items
         .map(adjustForItemInput)
-        .filter(
-          itemInput =>
-            orderFormItemsRef.current.findIndex(
-              orderFormItem => itemInput.id!.toString() === orderFormItem.id
-            ) === -1
+        .filter(itemInput => 
+          orderFormItemsRef.current.findIndex(
+            // @ts-ignore
+            orderFormItem => itemInput.id!.toString() === orderFormItem.id && itemInput.seller === orderFormItem.seller
+          ) === -1
         )
 
       const orderFormItems = mutationInputItems
         .map(itemInput => {
           const index = items.findIndex(
-            item => item.id === itemInput.id?.toString()
+            item => item.id === itemInput.id?.toString() && item.seller === itemInput.seller
           )
           return mapItemInputToOrderFormItem(itemInput, items[index])
         })
         .filter(
           orderFormItem =>
             orderFormItemsRef.current.findIndex(
-              (item: any) => item.id === orderFormItem.id
+              (item: any) =>
+                // @ts-ignore
+                item.id === orderFormItem.id && item.seller === orderFormItem.seller
             ) === -1
         )
 
@@ -504,6 +509,12 @@ export const OrderItemsProvider: FC = ({ children }) => {
         index = currentOrderFormItems.findIndex(
           (orderItem: any) => orderItem.id === input.id
         )
+
+        if (input.seller) {
+          index = currentOrderFormItems.findIndex(
+            (orderItem: any) => orderItem.id === input.id && orderItem.seller === input.seller
+          )
+        }
       } else if ('uniqueId' in input) {
         uniqueId = input.uniqueId
         index = currentOrderFormItems.findIndex(

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -196,7 +196,9 @@ const useAddItemsTask = (
         orderFormItems.forEach(orderFormItem => {
           const updatedItem = updatedOrderForm.items.find(
             // @ts-ignore
-            updatedOrderFormItem => updatedOrderFormItem.id === orderFormItem.id && updatedOrderFormItem.seller === orderFormItem.seller
+            updatedOrderFormItem =>
+              updatedOrderFormItem.id === orderFormItem.id &&
+              updatedOrderFormItem.seller === orderFormItem.seller
           )
 
           if (!updatedItem) {
@@ -225,7 +227,9 @@ const useAddItemsTask = (
               .map(item => {
                 const inputIndex = mutationInputItems.findIndex(
                   // @ts-ignore
-                  inputItem => inputItem.id === +item.id && inputItem.seller === item.seller
+                  inputItem =>
+                    inputItem.id === +item.id &&
+                    inputItem.seller === item.seller
                 )
 
                 if (inputIndex === -1) {
@@ -235,7 +239,9 @@ const useAddItemsTask = (
 
                 const updatedItem = updatedOrderForm.items.find(
                   // @ts-ignore
-                  updatedOrderFormItem => updatedOrderFormItem.id === item.id && updatedOrderFormItem.seller === item.seller
+                  updatedOrderFormItem =>
+                    updatedOrderFormItem.id === item.id &&
+                    updatedOrderFormItem.seller === item.seller
                 )
 
                 if (!updatedItem) {
@@ -430,19 +436,22 @@ export const OrderItemsProvider: FC = ({ children }) => {
       items: Array<Partial<CatalogItem>>,
       marketingData?: Partial<MarketingData>
     ) => {
-      const mutationInputItems = items
-        .map(adjustForItemInput)
-        .filter(itemInput => 
+      const mutationInputItems = items.map(adjustForItemInput).filter(
+        itemInput =>
           orderFormItemsRef.current.findIndex(
             // @ts-ignore
-            orderFormItem => itemInput.id!.toString() === orderFormItem.id && itemInput.seller === orderFormItem.seller
+            orderFormItem =>
+              itemInput.id!.toString() === orderFormItem.id &&
+              itemInput.seller === orderFormItem.seller
           ) === -1
-        )
+      )
 
       const orderFormItems = mutationInputItems
         .map(itemInput => {
           const index = items.findIndex(
-            item => item.id === itemInput.id?.toString() && item.seller === itemInput.seller
+            item =>
+              item.id === itemInput.id?.toString() &&
+              item.seller === itemInput.seller
           )
           return mapItemInputToOrderFormItem(itemInput, items[index])
         })
@@ -451,7 +460,8 @@ export const OrderItemsProvider: FC = ({ children }) => {
             orderFormItemsRef.current.findIndex(
               (item: any) =>
                 // @ts-ignore
-                item.id === orderFormItem.id && item.seller === orderFormItem.seller
+                item.id === orderFormItem.id &&
+                item.seller === orderFormItem.seller
             ) === -1
         )
 
@@ -512,7 +522,8 @@ export const OrderItemsProvider: FC = ({ children }) => {
 
         if (input.seller) {
           index = currentOrderFormItems.findIndex(
-            (orderItem: any) => orderItem.id === input.id && orderItem.seller === input.seller
+            (orderItem: any) =>
+              orderItem.id === input.id && orderItem.seller === input.seller
           )
         }
       } else if ('uniqueId' in input) {


### PR DESCRIPTION
#### What problem is this solving?

Add the same product (same skuId) with more than one seller in minicart

#### How to test it?

I have made a workspace with the [seller-sellector app](https://github.com/vtex-apps/seller-selector), using the [add-to-cart-button](https://github.com/vtex-apps/add-to-cart-button/), that uses order-items behind the scenes. If you do not link the change of this pull request you will not be able to add the same product from two sellers. You will be only able to add one product.

[Workspace without this fix](https://storetheme2--compracertamkpqa.myvtex.com/sellers/furadeira-e-parafusadeira-a-bateria-12v-3-8---reversivel-bivolt---ld12s-br---black-decker-2004802)
[Workspace with this fix](https://storetheme--compracertamkpqa.myvtex.com/sellers/furadeira-e-parafusadeira-a-bateria-12v-3-8---reversivel-bivolt---ld12s-br---black-decker-2004802)

#### Vídeo showing the problem and the solution:

https://drive.google.com/file/d/1C-ss2bBK71vf1pwb8FdxahFQ9ToyakpV/view?usp=sharing

#### Related to / Depends on
Related to [seller-sellector app](https://github.com/vtex-apps/seller-selector), using the [add-to-cart-button](https://github.com/vtex-apps/add-to-cart-button/). 

**I need help to add seller on type Item of vtex.checkout-graphql, for now I just put @ts-ignore because I can't find the types file**

#### How does this PR make you feel? About the seller difference:

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/C6JQPEUsZUyVq/giphy.gif)
