### PR TITLE
CHK-332: Add error logging in add and update items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add log if any error occurs in the add/update items mutations.
 
 ## [0.9.0] - 2020-09-25
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "vtex.checkout-graphql": "0.x",
     "vtex.checkout-resources": "0.x",
+    "vtex.checkout-splunk": "0.x",
     "vtex.order-manager": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/react/__mocks__/vtex.checkout-splunk.ts
+++ b/react/__mocks__/vtex.checkout-splunk.ts
@@ -1,0 +1,7 @@
+const logSplunk = jest.fn()
+const logKpiEvent = jest.fn()
+
+export const useSplunk = () => ({
+  logSplunk,
+  logKpiEvent,
+})

--- a/react/package.json
+++ b/react/package.json
@@ -37,6 +37,7 @@
     "typescript": "3.8.3",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.40.0/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.34.0/public/@types/vtex.checkout-resources",
+    "vtex.checkout-splunk": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-splunk@0.1.0/public/@types/vtex.checkout-splunk",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.6/public/@types/vtex.order-manager",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.121.0/public/@types/vtex.render-runtime"
   }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5235,6 +5235,10 @@ verror@1.10.0:
   version "0.34.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.34.0/public/@types/vtex.checkout-resources#603835e0d73ea4bc30a9ec6c3717532ccba912e6"
 
+"vtex.checkout-splunk@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-splunk@0.1.0/public/@types/vtex.checkout-splunk":
+  version "0.1.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-splunk@0.1.0/public/@types/vtex.checkout-splunk#d5670aa05efa8b7d4ee58750506d7e0ece85b8c8"
+
 "vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.6/public/@types/vtex.order-manager":
   version "0.8.6"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.6/public/@types/vtex.order-manager#7439a66d02f5d79fd48ff3b87f6e3c8586259396"


### PR DESCRIPTION
#### What problem is this solving?

Add logs if an error occurs in the add or update items mutations, so we can have a better observability on the errors ocurring in this component.

#### How to test it?

[Workspace](https://lucas--checkoutio.myvtex.com/).

Not much to test, since we would need to manually trigger an error, but it won't be logged because `checkout-splunk` only logs errors on production workspaces.

#### Screenshots or example usage:

N/A

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A
