### PR TITLE
CHK-479: Add support for sales channel in addItems function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `salesChannel` in `addItems` function.
 
 ## [0.9.3] - 2020-12-22
 ### Fixed

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -189,7 +189,11 @@ const useAddItemsTask = (
 ) => {
   const [mutateAddItem] = useMutation<
     { addToCart: OrderForm },
-    { items: OrderFormItemInput[]; marketingData?: Partial<MarketingData> }
+    {
+      items: OrderFormItemInput[]
+      marketingData?: Partial<MarketingData>
+      salesChannel?: string
+    }
   >(AddToCart)
 
   const { logSplunk } = useSplunk()
@@ -200,16 +204,19 @@ const useAddItemsTask = (
       mutationInputItems,
       mutationInputMarketingData,
       orderFormItems,
+      salesChannel,
     }: {
       mutationInputItems: OrderFormItemInput[]
       mutationInputMarketingData?: Partial<MarketingData>
       orderFormItems: Item[]
+      salesChannel?: string
     }) => ({
       execute: async () => {
         const { data, errors } = await mutateAddItem({
           variables: {
             items: mutationInputItems,
             marketingData: mutationInputMarketingData,
+            salesChannel,
           },
         })
 
@@ -578,7 +585,8 @@ const OrderItemsProvider: FC = ({ children }) => {
   const addItem = useCallback(
     (
       items: Array<Partial<CatalogItem>>,
-      marketingData?: Partial<MarketingData>
+      marketingData?: Partial<MarketingData>,
+      salesChannel?: string
     ) => {
       const { newItems, updatedItems } = items.reduce<
         Record<string, Array<Partial<CatalogItem>>>
@@ -644,6 +652,7 @@ const OrderItemsProvider: FC = ({ children }) => {
         variables: {
           items: mutationInputItems,
           marketingData,
+          salesChannel,
         },
         orderFormItems,
       })
@@ -653,6 +662,7 @@ const OrderItemsProvider: FC = ({ children }) => {
           mutationInputItems,
           mutationInputMarketingData: marketingData,
           orderFormItems,
+          salesChannel,
         })
       )
     },
@@ -686,6 +696,7 @@ const OrderItemsProvider: FC = ({ children }) => {
             mutationInputItems: task.variables.items,
             mutationInputMarketingData: task.variables.marketingData,
             orderFormItems: task.orderFormItems,
+            salesChannel: task.variables.salesChannel,
           })
         )
       } else if (task.type === LocalOrderTaskType.UPDATE_MUTATION) {

--- a/react/modules/OrderItemsContext.ts
+++ b/react/modules/OrderItemsContext.ts
@@ -3,7 +3,8 @@ import { useContext, createContext } from 'react'
 interface Context {
   addItem: (
     items: Array<Partial<CatalogItem>>,
-    marketingData?: Partial<MarketingData>
+    marketingData?: Partial<MarketingData>,
+    salesChannel?: string
   ) => void
   updateQuantity: (props: Partial<CatalogItem>) => void
   removeItem: (props: Partial<CatalogItem>) => void

--- a/react/modules/localOrderQueue.ts
+++ b/react/modules/localOrderQueue.ts
@@ -17,6 +17,7 @@ interface UpdateQuantityMutationVariables {
 interface AddItemMutationVariables {
   items: OrderFormItemInput[]
   marketingData?: Partial<MarketingData>
+  salesChannel?: string
 }
 
 type LocalOrderTask =


### PR DESCRIPTION
#### What problem is this solving?

Add support for the `salesChannel` parameter in `addItems` context function.

#### How to test it?

[Workspace](https://saleschannel--checkoutio.myvtex.com/cart/add?sku=312&sc=2).

Notice the `sc=2` parameter in the query string of the add-to-cart URL above, this will add Produto Global of the sales channel 2, which is configured to be delivered in all countries (you can confirm this by going to shipping in checkout and seeing the Location Country component being displayed).

#### Screenshots or example usage:

https://user-images.githubusercontent.com/10223856/102922607-0e7b0780-446d-11eb-898d-9ed4fcdbe0e7.mov

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

vtex-apps/checkout-graphql#116
vtex-apps/checkout-resources#66
