### PR TITLE
feat: add support for price token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Forward the search-signed `priceToken` (Pricing Fallback V2) on the add to cart mutation input. `adjustForItemInput` lives in `@vtex/order-items` and whitelists the fields it forwards, so `useOrderItems` now stashes the token per SKU + seller when the item is added and re-attaches it to the mutation variables. This bridge can be dropped once the field ships in the library.
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -38,7 +38,7 @@ type OfferWithPriceToken = {
 }
 
 function stashPriceTokens(items: OfferWithPriceToken[]) {
-  items.forEach(item => {
+  items.forEach((item) => {
     if (item?.priceToken) {
       priceTokenByOffer.set(offerKey(item.id, item.seller), item.priceToken)
     }
@@ -50,11 +50,13 @@ function withPriceTokens(variables: AddToCartMutationVariables) {
     return variables
   }
 
-  const items = ((variables.items ?? []) as OfferWithPriceToken[]).map(item => {
-    const priceToken = priceTokenByOffer.get(offerKey(item?.id, item?.seller))
+  const items = ((variables.items ?? []) as OfferWithPriceToken[]).map(
+    (item) => {
+      const priceToken = priceTokenByOffer.get(offerKey(item?.id, item?.seller))
 
-    return priceToken ? { ...item, priceToken } : item
-  })
+      return priceToken ? { ...item, priceToken } : item
+    }
+  )
 
   return { ...variables, items } as AddToCartMutationVariables
 }

--- a/react/OrderItems.tsx
+++ b/react/OrderItems.tsx
@@ -11,10 +11,69 @@ import {
 import type { OrderForm } from 'vtex.checkout-graphql'
 import { OrderForm as OrderManager, OrderQueue } from 'vtex.order-manager'
 import { useSplunk } from 'vtex.checkout-splunk'
-import { useOrderItems, createOrderItemsProvider } from '@vtex/order-items'
+import {
+  useOrderItems as useBaseOrderItems,
+  createOrderItemsProvider,
+} from '@vtex/order-items'
 
 const { useOrderForm } = OrderManager
 const { useOrderQueue, useQueueStatus } = OrderQueue
+
+/**
+ * `adjustForItemInput` in `@vtex/order-items` whitelists the fields it forwards
+ * to the mutation, so `priceToken` (signed price, Pricing Fallback V2) is
+ * dropped before it reaches checkout. Until the field ships upstream, the token
+ * is stashed when the caller adds the item and re-attached to the mutation
+ * variables. Keyed by SKU + seller, which is what identifies an offer.
+ */
+const priceTokenByOffer = new Map<string, string>()
+
+const offerKey = (id?: string | number | null, seller?: string | null) =>
+  `${id ?? ''}::${seller ?? ''}`
+
+type OfferWithPriceToken = {
+  id?: string | number | null
+  seller?: string | null
+  priceToken?: string | null
+}
+
+function stashPriceTokens(items: OfferWithPriceToken[]) {
+  items.forEach(item => {
+    if (item?.priceToken) {
+      priceTokenByOffer.set(offerKey(item.id, item.seller), item.priceToken)
+    }
+  })
+}
+
+function withPriceTokens(variables: AddToCartMutationVariables) {
+  if (priceTokenByOffer.size === 0) {
+    return variables
+  }
+
+  const items = ((variables.items ?? []) as OfferWithPriceToken[]).map(item => {
+    const priceToken = priceTokenByOffer.get(offerKey(item?.id, item?.seller))
+
+    return priceToken ? { ...item, priceToken } : item
+  })
+
+  return { ...variables, items } as AddToCartMutationVariables
+}
+
+function useOrderItems() {
+  const orderItems = useBaseOrderItems()
+  const { addItems } = orderItems
+
+  const addItemsWithPriceToken = useCallback<typeof addItems>(
+    (items, options) => {
+      stashPriceTokens(items as OfferWithPriceToken[])
+
+      return addItems(items, options)
+    },
+    [addItems]
+  )
+
+  return { ...orderItems, addItems: addItemsWithPriceToken }
+}
 
 function useLogger() {
   const { logSplunk } = useSplunk()
@@ -45,9 +104,11 @@ function useMutateAddItems() {
 
   return useCallback(
     (variables: AddToCartMutationVariables) => {
-      return mutateAddItem({ variables }).then(({ data, errors }) => {
-        return { data: data?.addToCart, errors }
-      })
+      return mutateAddItem({ variables: withPriceTokens(variables) }).then(
+        ({ data, errors }) => {
+          return { data: data?.addToCart, errors }
+        }
+      )
     },
     [mutateAddItem]
   )


### PR DESCRIPTION
#### What problem is this solving?

`adjustForItemInput` in `@vtex/order-items` whitelists the fields it forwards to the
mutation, so `priceToken` was stripped between the caller and the GraphQL variables —
every upstream app could set the token correctly and it would still never reach checkout.

Until the field ships in the library, this bridges it: `useOrderItems` wraps the base
hook, stashes the token per SKU + seller when the item is added, and `useMutateAddItems`
re-attaches it to the variables. Keyed on SKU + seller, which is what identifies an offer.

#### How to test it?

[Workspace](https://vysk--biggy.myvtex.com/apparel---accessories/roupa?__bindingAddress=biggy.myvtex.com/)

Add a shelf item and inspect the `addToCart` request: the item carries `priceToken` and
checkout closes the line at the signed price. With price signing off, the cache stays
empty and variables pass through untouched.

#### Describe alternatives you've considered, if any.

`patch-package` on `@vtex/order-items`. Implemented first, then abandoned: `builder-hub`
does not run `postinstall` remotely, so the patch never applied in a linked or published
build. The shim lives in app source precisely so it survives the cloud build.

Fixing it upstream in `@vtex/order-items` is the real fix and should follow — this bridge
is deliberately small and easy to delete.

#### Related to / Depends on

- `vtex.checkout-graphql` — `ItemInput.priceToken`
- `vtex.add-to-cart-button` / `vtex.store-components` — set the token on the item

The type casts exist because the published `vtex.checkout-resources` typings generate
`ItemInput` from the checkout-graphql schema at *its* publish time. They can be removed
once checkout-graphql ships and checkout-resources is rebuilt.